### PR TITLE
ci: pkgcraft: manually sync ::gentoo repo for now

### DIFF
--- a/.github/workflows/pkgcraft.yml
+++ b/.github/workflows/pkgcraft.yml
@@ -9,5 +9,21 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    # currently the pkgcruft-action doesn't natively handle repo syncing
+    # see https://github.com/pkgcraft/pkgcruft-action/issues/2
+    - name: Checkout Gentoo repo and mangle /etc/portage/repos.conf
+      shell: bash
+      run: |
+        mkdir -p "${HOME}/.cache/pkgcruft/repos/gentoo"
+        curl -L https://github.com/gentoo-mirror/gentoo/archive/stable.tar.gz | tar -zxf - --strip-components=1 -C "${HOME}/.cache/pkgcruft/repos/gentoo"
+        dir=$(mktemp -d)
+        cat <<- EOF > "${dir}/repos.conf"
+        [DEFAULT]
+        main-repo = gentoo
+        [gentoo]
+        location = "${HOME}/.cache/pkgcruft/repos/gentoo"
+        EOF
+        sudo mv "${dir}" /etc/portage
+
     - name: Run pkgcruft
       uses: pkgcraft/pkgcruft-action@main


### PR DESCRIPTION
Thanks to radhermit for giving an example at https://github.com/pkgcraft/pkgcruft-action/commit/72c7946600e7a5d49c1eda2dab7602641bb0cd69.

Bug: https://github.com/pkgcraft/pkgcruft-action/issues/2